### PR TITLE
Don't send greetings by default and raise a proper exception on channel resolution failure

### DIFF
--- a/djangobot/client.py
+++ b/djangobot/client.py
@@ -72,7 +72,7 @@ class SlackClientProtocol(WebSocketClientProtocol):
         # translate user
         try:
             user_id = message.pop('user')
-            user = self.slack.user_from_id(user_id) 
+            user = self.slack.user_from_id(user_id)
             message[u'user'] = user['name']
         except (KeyError, IndexError, ValueError):
             pass
@@ -85,15 +85,11 @@ class SlackClientProtocol(WebSocketClientProtocol):
             pass
         return message
 
-    def sendHello(self):
-        self.sendMessage(self.make_message('<yawn /> Why hello there.', 'general'))
-
     def onOpen(self):
         """
         Store this protocol instance in the factory and wave hello.
         """
         self.factory.protocols.append(self)
-        self.sendHello()
 
     def onMessage(self, payload, isBinary):
         """

--- a/djangobot/slack.py
+++ b/djangobot/slack.py
@@ -120,6 +120,6 @@ class SlackAPI(object):
             channel = [channel for channel in self.channels
                        if channel['id'] == channel_id][0]
         except IndexError:
-            raise Exception('Unknown channel for id: "{}"'.format(channel_id))
+            raise ValueError('Unknown channel for id: "{}"'.format(channel_id))
         else:
             return channel


### PR DESCRIPTION
Hi djangobot maintainers, 

These two commits are the fixes for the few minor issues I encountered right after installing djangobot:

1. Djangobot crashes on I try to PM the bot. It turns out that the issue is that channel_from_id raises the wrong type of exception.

2. There's no way to opt out of default hello message sent by django bot to 'general' channel. I think that it's better to let the user decide how to react to message on 'slack.hello' channel and don't do anything by default.