### PR TITLE
Added support for posting attachments via the chat.postMessage api call.

### DIFF
--- a/djangobot/client.py
+++ b/djangobot/client.py
@@ -19,6 +19,7 @@ def pack(message):
     """
     return json.dumps(message).encode('utf8')
 
+
 def unpack(text):
     """
     Decode & Load
@@ -113,7 +114,13 @@ class SlackClientProtocol(WebSocketClientProtocol):
         Send message to Slack
         """
         channel = message.get('channel', 'general')
-        self.sendMessage(self.make_message(message['text'], channel))
+        attachments = message.get('attachments', None)
+
+        if attachments:
+            self.slack.chat_post_message(channel=channel, text=message['text'],
+                                         attachments=attachments)
+        else:
+            self.sendMessage(self.make_message(message['text'], channel))
 
 
 class SlackClientFactory(WebSocketClientFactory):

--- a/djangobot/slack.py
+++ b/djangobot/slack.py
@@ -63,7 +63,7 @@ class SlackAPI(object):
 
         Args:
             method: {str} method name to call
-            params: {dict} GET parameters
+            params: {dict} JSON parameters
                 The token will always be added
         """
         headers = {
@@ -80,8 +80,8 @@ class SlackAPI(object):
 
         Args:
             method: {str} method name to call
-            params: {dict} GET parameters
-                The token will always be added
+            request_method: {str} HTTP method to use for the call.
+            request_kwargs: {dict} arguments to pass to the requests call
         """
         url = self.url.format(method=method)
         logger.debug('Send request to %s', url)

--- a/djangobot/slack.py
+++ b/djangobot/slack.py
@@ -28,11 +28,11 @@ class SlackAPI(object):
             self.token = token if token else os.environ['SLACK_TOKEN']
         except KeyError:
             raise ValueError('If not providing a token, must set SLACK_TOKEN envvar')
+        self.verify = verify
         if auth_test:
             response = self.auth_test()
             if not response['ok']:
                 raise ValueError('Authentication Failed with response: {}'.format(response))
-        self.verify = verify
 
         # Attributes backing properties
         self._channels = []
@@ -44,6 +44,38 @@ class SlackAPI(object):
 
     def _call_api(self, method, params=None):
         """
+        Low-level method to call the Slack API via GET.
+
+        Args:
+            method: {str} method name to call
+            params: {dict} GET parameters
+                The token will always be added
+        """
+        if not params:
+            params = {'token': self.token}
+        else:
+            params['token'] = self.token
+        return self._api_call(method, 'get', {'params': params})
+
+    def _post_api(self, method, params=None):
+        """
+        Low-level method to call the Slack API via POST.
+
+        Args:
+            method: {str} method name to call
+            params: {dict} GET parameters
+                The token will always be added
+        """
+        headers = {
+            'Authorization': 'Bearer {}'.format(self.token),
+        }
+        return self._api_call(method, 'post', {
+            'headers': headers,
+            'json': params,
+        })
+
+    def _api_call(self, method, request_method, request_kwargs):
+        """
         Low-level method to call the Slack API.
 
         Args:
@@ -52,12 +84,9 @@ class SlackAPI(object):
                 The token will always be added
         """
         url = self.url.format(method=method)
-        if not params:
-            params = {'token': self.token}
-        else:
-            params['token'] = self.token
         logger.debug('Send request to %s', url)
-        response = requests.get(url, params=params).json()
+        response = getattr(requests, request_method)(url, **request_kwargs).json()
+
         if self.verify:
             if not response['ok']:
                 msg = 'For {url} API returned this bad response {response}'
@@ -87,13 +116,22 @@ class SlackAPI(object):
         """
         Call auth.test
         """
-        return self._call_api('auth.test')
+        return self._call_api('auth.test') and self._post_api('auth.test')
 
     def rtm_start(self):
         """
         Call rtm.start
         """
         return self._call_api('rtm.start')
+
+    def chat_post_message(self, **params):
+        """
+        Post to chat.postMessage
+
+        :param params: arguments to pass
+        :return:
+        """
+        self._post_api('chat.postMessage', params)
 
     # Translation
     def channel_from_name(self, name):


### PR DESCRIPTION
The bot was not yet able to post attachments since this happens via the web api instead of the rtm api. These adjustments allow for attachments to be sent with slack messages. The syntax for providing attachments being the syntax as described on slack: https://api.slack.com/methods/chat.postMessage. 

Example:
`Channel('slack.send').send({'text': 'hello', 'channel': 'general', 'attachments': [{'title': 'image', 'image_url': 'https://mysite.com/my/image.png'}]})`